### PR TITLE
Set RuntimeLibrary (Multithreaded DLL, etc) setting for VS2019 to default for libCgl

### DIFF
--- a/MSVisualStudio/v16/libCgl/libCgl.vcxproj
+++ b/MSVisualStudio/v16/libCgl/libCgl.vcxproj
@@ -125,7 +125,6 @@
       <AdditionalIncludeDirectories>..\..\..\..\BuildTools\headers;..\..\..\..\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglProbing;..\..\..\src;..\..\..\..\Osi\src\Osi;..\..\..\..\Clp\src\OsiClp;..\..\..\..\Clp\src</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_NDEBUG;WIN32;_LIB;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
For libCgl this PR sets RuntimeLibrary (Multithreaded DLL, etc. --how to link in the Microsoft Run-Time library MSVCRT / LIBCMT) for VS2019 to default values for all configurations by removing explicit values.

All Debug configs (Config -> C/C++ -> Code Generation) were at defaults, but Release were various, leading to link errors when linking multiple libraries together. These conflicts are prevented if all simply use the default (Multithreaded DLL (Debug or Release)). This has nothing to do with the result of the Configuration Type (static lib, dll, exe, etc.), but only how the MS runtimes are linked.