### PR TITLE
Add VS2022 and its windows-ci to stable 0.60

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,6 +26,7 @@ jobs:
           { os: windows-2019, arch: i686, msystem: mingw32, debug: false, suffix: "" },
           { os: windows-2019, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
           { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2022, arch: msvs, msystem: mingw64, debug: false, suffix: "" },
         ]
     steps:
       - name: Checkout source
@@ -40,11 +41,14 @@ jobs:
       - name: Set up msvc
         if: ${{ matrix.arch == 'msvc' }}
         uses: ilammy/msvc-dev-cmd@v1
+      - name: Set up for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        uses: microsoft/setup-msbuild@v1.1
       - name: Set correct host flag and install requirements
+        if: ${{ matrix.arch != 'msvc' && matrix.arch != 'msvs' }}
         run: |
           echo "host_flag=--host=${{ matrix.arch }}-w64-mingw32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           C:\msys64\usr\bin\pacman -S mingw-w64-${{ matrix.arch }}-lapack mingw-w64-${{ matrix.arch }}-winpthreads-git mingw-w64-${{ matrix.arch }}-readline mingw-w64-${{ matrix.arch }}-suitesparse mingw-w64-${{ matrix.arch }}-metis --noconfirm
-        if: ${{ matrix.arch != 'msvc' }}
       - name: Set up msys with ${{ matrix.msystem }}
         uses: msys2/setup-msys2@v2
         with:
@@ -55,7 +59,44 @@ jobs:
             zip
           path-type: inherit
           msystem: ${{ matrix.msystem }}
-      - name: Build project
+      - name: Fetch project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        run: |
+          ADD_ARGS=()
+          ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
+          ./coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update "${ADD_ARGS[@]}"
+          echo "##################################################"
+          echo "### Extracting Netlib and Miplib3 if available"
+          if [ -d "./Data/Netlib/" ]; then gunzip ./Data/Netlib/*.gz; fi
+          if [ -d "./Data/Miplib3/" ]; then gunzip ./Data/Miplib3/*.gz; fi
+          echo "##################################################"       
+        shell: msys2 {0}
+      - name: Build project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          msbuild ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=Release /p:Platform=x64 /m
+      - name: Test project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
+      - name: Install project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          mkdir dist
+          copy ${{ github.event.repository.name }}\README.* dist\.
+          copy ${{ github.event.repository.name }}\AUTHORS.* dist\.
+          copy ${{ github.event.repository.name }}\LICENSE.* dist\.
+          mkdir dist\bin
+          copy ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release\*.exe dist\bin\.
+          mkdir dist\share
+          if exist .\Data\Sample xcopy .\Data\Sample dist\share\coin-or-sample /i
+          if exist .\Data\Netlib xcopy .\Data\Netlib dist\share\coin-or-netlib /i
+          if exist .\Data\Miplib3 xcopy .\Data\Miplib3 dist\share\coin-or-miplib3 /i
+      - name: Build project using coinbrew
+        if: ${{ matrix.arch != 'msvs' }}
         run: |
           ADD_ARGS=()
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Ignore VS files
+*.suo
+*.db
+*.bak
+*.user
+**/.vs/
+**/MSVisualStudio/**/Release/
+**/MSVisualStudio/**/ReleaseParallel/
+**/MSVisualStudio/**/Debug/
+
+# Ignore files created during unit tests
+**/MSVisualStudio/**/*.mps
+**/MSVisualStudio/**/*.lp
+**/MSVisualStudio/**/*.out

--- a/Cgl/MSVisualStudio/v17/Cgl.sln
+++ b/Cgl/MSVisualStudio/v17/Cgl.sln
@@ -1,0 +1,106 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32804.467
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCgl", "libCgl\libCgl.vcxproj", "{1E645A44-00EF-4093-9F6A-1D082BD43BDB}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CglUnitTest", "CglUnitTest\CglUnitTest.vcxproj", "{FCF90EF8-93AE-482A-9B55-018B8338B99D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libClp", "..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj", "{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsiClp", "..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj", "{79433425-EC16-410F-9B91-8D31D2109C90}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCoinUtils", "..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj", "{6D2EF92A-D693-47E3-A325-A686E78C5FFD}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsi", "..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj", "{BF5C7532-EE0A-479B-9993-72134087D530}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{657AF492-1E1A-430A-96AF-93039CF6F2E5}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.gitignore = ..\..\..\.gitignore
+		..\..\..\AUTHORS = ..\..\..\AUTHORS
+		..\..\..\LICENSE = ..\..\..\LICENSE
+		..\..\..\README.md = ..\..\..\README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{FA2B8E71-DD6B-4A8D-8052-69AB758A1144}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.github\workflows\linux-ci.yml = ..\..\..\.github\workflows\linux-ci.yml
+		..\..\..\.github\workflows\release.yml = ..\..\..\.github\workflows\release.yml
+		..\..\..\.github\workflows\windows-ci.yml = ..\..\..\.github\workflows\windows-ci.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{14BDCE3D-C9CE-4739-9A78-C3BE5FD99887}"
+	ProjectSection(SolutionItems) = preProject
+		CglTest.cmd = CglTest.cmd
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x64.ActiveCfg = Debug|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x64.Build.0 = Debug|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x86.ActiveCfg = Debug|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x86.Build.0 = Debug|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x64.ActiveCfg = Release|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x64.Build.0 = Release|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x86.ActiveCfg = Release|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x86.Build.0 = Release|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x64.ActiveCfg = Debug|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x64.Build.0 = Debug|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x86.ActiveCfg = Debug|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Debug|x86.Build.0 = Debug|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x64.ActiveCfg = Release|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x64.Build.0 = Release|x64
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x86.ActiveCfg = Release|Win32
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D}.Release|x86.Build.0 = Release|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x64.ActiveCfg = Debug|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x64.Build.0 = Debug|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x86.ActiveCfg = Debug|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x86.Build.0 = Debug|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x64.ActiveCfg = Release|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x64.Build.0 = Release|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x86.ActiveCfg = Release|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x86.Build.0 = Release|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x64.ActiveCfg = Debug|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x64.Build.0 = Debug|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x86.ActiveCfg = Debug|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x86.Build.0 = Debug|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x64.ActiveCfg = Release|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x64.Build.0 = Release|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x86.ActiveCfg = Release|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x86.Build.0 = Release|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x64.ActiveCfg = Debug|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x64.Build.0 = Debug|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x86.ActiveCfg = Debug|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x86.Build.0 = Debug|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x64.ActiveCfg = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x64.Build.0 = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x86.ActiveCfg = Release|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x86.Build.0 = Release|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x64.ActiveCfg = Debug|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x64.Build.0 = Debug|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x86.ActiveCfg = Debug|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x86.Build.0 = Debug|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x64.ActiveCfg = Release|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x64.Build.0 = Release|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x86.ActiveCfg = Release|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D} = {14BDCE3D-C9CE-4739-9A78-C3BE5FD99887}
+		{FA2B8E71-DD6B-4A8D-8052-69AB758A1144} = {657AF492-1E1A-430A-96AF-93039CF6F2E5}
+		{14BDCE3D-C9CE-4739-9A78-C3BE5FD99887} = {657AF492-1E1A-430A-96AF-93039CF6F2E5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E601D15F-D808-415A-BE0E-C62970CA4DBE}
+	EndGlobalSection
+EndGlobal

--- a/Cgl/MSVisualStudio/v17/CglTest.cmd
+++ b/Cgl/MSVisualStudio/v17/CglTest.cmd
@@ -1,0 +1,55 @@
+@REM This file will run command line tests, comparable to test\makefile.am
+
+@echo off
+SET "BINDIR=%~1"
+SET "SAMPLEDIR=%~2"
+SET "NETLIBDIR=%~3"
+SET "MIPLIBDIR=%~4"
+
+echo INFO: Running %0 %*
+echo INFO: Using bindir '%BINDIR%' and sampledir '%SAMPLEDIR%'. 
+echo INFO: Netlibdir '%NETLIBDIR%' and miplibdir '%MIPLIBDIR%' are ignored for these tests.
+
+if "%BINDIR%"=="" echo ERROR: No bindir given. && goto :usage
+if not exist "%BINDIR%" echo ERROR: Folder bindir %BINDIR% does not exist. && goto :usage
+
+if "%SAMPLEDIR%"=="" echo ERROR: No sampledir given. && goto :usage
+if not exist %SAMPLEDIR% echo ERROR: Folder sampledir %SAMPLEDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %SAMPLEDIR% cannot contain spaces. && goto :usage
+
+@REM if "%NETLIBDIR%"=="" echo ERROR: No netlibdir given. && goto :usage
+@REM if not exist %NETLIBDIR% echo ERROR: Folder netlibdir %NETLIBDIR% does not exist. && goto :usage
+@REM if not %errorlevel%==0 echo ERROR: %NETLIBDIR% cannot contain spaces. && goto :usage
+
+@REM if "%MIPLIBDIR%"=="" echo ERROR: No miplibdir given. && goto :usage
+@REM if not exist %MIPLIBDIR% echo ERROR: Folder miplibdir %MIPLIBDIR% does not exist. && goto :usage
+@REM if not %errorlevel%==0 echo ERROR: %MIPLIBDIR% cannot contain spaces. && goto :usage
+
+goto :test
+
+:usage
+echo INFO: Usage %0 ^<bindir^> ^<sampledir^>
+echo INFO: where ^<bindir^> contains the executables, sampledir the sample files.
+echo INFO: This script runs automated test.
+echo INFO: The sampledir must not contain spaces!
+echo INFO: For example: %0 "D:\Some Directory\" ..\..\samples\
+goto :error
+
+:error
+echo ERROR: An error occurred while running the tests!
+echo INFO: Finished Tests but failed
+exit /b 1
+
+:test
+echo INFO: Initializing Tests
+SET "CGLTESTDATADIR=%~dp0..\..\test\CglTestData"
+if not exist "%CGLTESTDATADIR%" echo ERROR: Folder CglTestData %CGLTESTDATADIR% does not exist. && goto :error 
+
+echo INFO: Starting Tests
+@echo on
+
+"%BINDIR%\CglUnitTest.exe" %SAMPLEDIR% "%CGLTESTDATADIR%"
+@if not %errorlevel%==0 goto :error
+
+@echo off
+echo INFO: Finished Tests successfully (%ERRORLEVEL%)

--- a/Cgl/MSVisualStudio/v17/CglUnitTest/CglUnitTest.vcxproj
+++ b/Cgl/MSVisualStudio/v17/CglUnitTest/CglUnitTest.vcxproj
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{fcf90ef8-93ae-482a-9b55-018b8338b99d}</ProjectGuid>
+    <RootNamespace>CglUnitTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>CGL_BUILD;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\CoinUtils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>CGL_BUILD;_CONSOLE;_CRT_SECURE_NO_WARNINGS;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\CoinUtils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>CGL_BUILD;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\CoinUtils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>CGL_BUILD;_CONSOLE;_CRT_SECURE_NO_WARNINGS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\CoinUtils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\CglClique\CglCliqueTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglFlowCover\CglFlowCoverTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglGomory\CglGomoryTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglKnapsackCover\CglKnapsackCoverTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandPTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglMixedIntegerRounding2\CglMixedIntegerRounding2Test.cpp" />
+    <ClCompile Include="..\..\..\src\CglMixedIntegerRounding\CglMixedIntegerRoundingTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglOddHole\CglOddHoleTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglProbing\CglProbingTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglRedSplit2\CglRedSplit2Test.cpp" />
+    <ClCompile Include="..\..\..\src\CglRedSplit\CglRedSplitTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglResidualCapacity\CglResidualCapacityTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglSimpleRounding\CglSimpleRoundingTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglTwomir\CglTwomirTest.cpp" />
+    <ClCompile Include="..\..\..\src\CglZeroHalf\CglZeroHalfTest.cpp" />
+    <ClCompile Include="..\..\..\test\unitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCgl\libCgl.vcxproj">
+      <Project>{1e645a44-00ef-4093-9f6a-1d082bd43bdb}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cgl/MSVisualStudio/v17/libCgl/libCgl.vcxproj
+++ b/Cgl/MSVisualStudio/v17/libCgl/libCgl.vcxproj
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{1E645A44-00EF-4093-9F6A-1D082BD43BDB}</ProjectGuid>
+    <RootNamespace>libCgl</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Coinutils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CGL_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Coinutils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CGL_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Coinutils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CGL_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Coinutils\CoinUtils\src\;..\..\..\src\CglCommon;..\..\..\src\CglDuplicateRow;..\..\..\src\CglMixedIntegerRounding;..\..\..\src\CglMixedIntegerRounding2;..\..\..\src\CglFlowCover;..\..\..\src\CglClique;..\..\..\src\CglOddHole;..\..\..\src\CglLandP;..\..\..\src\CglKnapsackCover;..\..\..\src\CglGomory;..\..\..\src\CglPreProcess;..\..\..\src\CglRedSplit;..\..\..\src\CglResidualCapacity;..\..\..\src\CglSimpleRounding;..\..\..\src\CglTwomir;..\..\..\src\CglRedSplit2;..\..\..\src\CglProbing;..\..\..\src\CglZeroHalf;..\..\..\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Clp\Clp\src</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CGL_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\CglAllDifferent\CglAllDifferent.cpp" />
+    <ClCompile Include="..\..\..\src\CglClique\CglClique.cpp" />
+    <ClCompile Include="..\..\..\src\CglClique\CglCliqueHelper.cpp" />
+    <ClCompile Include="..\..\..\src\CglCutGenerator.cpp" />
+    <ClCompile Include="..\..\..\src\CglDuplicateRow\CglDuplicateRow.cpp" />
+    <ClCompile Include="..\..\..\src\CglFlowCover\CglFlowCover.cpp" />
+    <ClCompile Include="..\..\..\src\CglGMI\CglGMI.cpp" />
+    <ClCompile Include="..\..\..\src\CglGMI\CglGMIParam.cpp" />
+    <ClCompile Include="..\..\..\src\CglGomory\CglGomory.cpp" />
+    <ClCompile Include="..\..\..\src\CglKnapsackCover\CglKnapsackCover.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandP.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandPMessages.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandPSimplex.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandPTabRow.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandPUtils.cpp" />
+    <ClCompile Include="..\..\..\src\CglLandP\CglLandPValidator.cpp" />
+    <ClCompile Include="..\..\..\src\CglLiftAndProject\CglLiftAndProject.cpp" />
+    <ClCompile Include="..\..\..\src\CglMessage.cpp" />
+    <ClCompile Include="..\..\..\src\CglMixedIntegerRounding\CglMixedIntegerRounding.cpp" />
+    <ClCompile Include="..\..\..\src\CglMixedIntegerRounding2\CglMixedIntegerRounding2.cpp" />
+    <ClCompile Include="..\..\..\src\CglOddHole\CglOddHole.cpp" />
+    <ClCompile Include="..\..\..\src\CglParam.cpp" />
+    <ClCompile Include="..\..\..\src\CglPreProcess\CglPreProcess.cpp" />
+    <ClCompile Include="..\..\..\src\CglProbing\CglProbing.cpp" />
+    <ClCompile Include="..\..\..\src\CglRedSplit2\CglRedSplit2.cpp" />
+    <ClCompile Include="..\..\..\src\CglRedSplit2\CglRedSplit2Param.cpp" />
+    <ClCompile Include="..\..\..\src\CglRedSplit\CglRedSplit.cpp" />
+    <ClCompile Include="..\..\..\src\CglRedSplit\CglRedSplitParam.cpp" />
+    <ClCompile Include="..\..\..\src\CglResidualCapacity\CglResidualCapacity.cpp" />
+    <ClCompile Include="..\..\..\src\CglSimpleRounding\CglSimpleRounding.cpp" />
+    <ClCompile Include="..\..\..\src\CglStored.cpp" />
+    <ClCompile Include="..\..\..\src\CglTreeInfo.cpp" />
+    <ClCompile Include="..\..\..\src\CglTwomir\CglTwomir.cpp" />
+    <ClCompile Include="..\..\..\src\CglZeroHalf\Cgl012cut.cpp" />
+    <ClCompile Include="..\..\..\src\CglZeroHalf\CglZeroHalf.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\CglConfig.h" />
+    <ClInclude Include="..\..\..\src\configall_system.h" />
+    <ClInclude Include="..\..\..\src\configall_system_msc.h" />
+    <ClInclude Include="..\..\..\src\config_cgl_default.h" />
+    <ClInclude Include="..\..\..\src\config_default.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cgl/src/configall_system.h
+++ b/Cgl/src/configall_system.h
@@ -1,0 +1,13 @@
+/*
+ * This header file is included by the *Config.h in the individual
+ * COIN packages when the code is compiled in a setting that doesn't
+ * use the configure script (i.e., HAVE_CONFIG_H is not defined).
+ * This header file includes the system and compile dependent header
+ * file defining macros that depend on what compiler is used.
+ */
+
+#ifdef _MSC_VER
+# include "configall_system_msc.h"
+#else
+# error "Trying to use configall_system for unknown compiler."
+#endif

--- a/Cgl/src/configall_system_msc.h
+++ b/Cgl/src/configall_system_msc.h
@@ -1,0 +1,145 @@
+/* This is the header file for the Microsoft compiler, defining all
+ * system and compiler dependent configuration macros */
+
+/* Define to dummy `main' function (if any) required to link to the Fortran
+   libraries. */
+/* #undef F77_DUMMY_MAIN */
+
+#ifndef COIN_USE_F2C
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+# define F77_FUNC(name,NAME) NAME
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+# define F77_FUNC_(name,NAME) NAME
+#else
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+# define F77_FUNC(name,NAME) name ## _
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+# define F77_FUNC_(name,NAME) name ## __
+#endif
+
+/* Define if F77 and FC dummy `main' functions are identical. */
+/* #undef FC_DUMMY_MAIN_EQ_F77 */
+
+/* Define to 1 if you have the <assert.h> header file. */
+/* #undef HAVE_ASSERT_H */
+
+/* Define to 1 if you have the <cassert> header file. */
+#define HAVE_CASSERT 1
+
+/* Define to 1 if you have the <cctype> header file. */
+#define HAVE_CCTYPE 1
+
+/* Define to 1 if you have the <cfloat> header file. */
+#define HAVE_CFLOAT 1
+
+/* Define to 1 if you have the <cieeefp> header file. */
+/* #undef HAVE_CIEEEFP */
+
+/* Define to 1 if you have the <cmath> header file. */
+#define HAVE_CMATH 1
+
+/* Define to 1 if you have the <cstdarg> header file. */
+#define HAVE_CSTDARG 1
+
+/* Define to 1 if you have the <cstdio> header file. */
+#define HAVE_CSTDIO 1
+
+/* Define to 1 if you have the <cstdlib> header file. */
+#define HAVE_CSTDLIB 1
+
+/* Define to 1 if you have the <cstring> header file. */
+#define HAVE_CSTRING 1
+
+/* Define to 1 if you have the <ctime> header file. */
+#define HAVE_CTIME 1
+
+/* Define to 1 if you have the <cstddef> header file. */
+#define HAVE_CSTDDEF 1
+
+/* Define to 1 if you have the <ctype.h> header file. */
+/* #undef HAVE_CTYPE_H */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if function drand48 is available */
+/* #undef HAVE_DRAND48 */
+
+/* Define to 1 if you have the <float.h> header file. */
+/* #undef HAVE_FLOAT_H */
+
+/* Define to 1 if you have the <ieeefp.h> header file. */
+/* #undef HAVE_IEEEFP_H */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+/* #define HAVE_INTTYPES_H */
+
+/* Define to 1 if you have the <math.h> header file. */
+/* #undef HAVE_MATH_H */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if function rand is available */
+#define HAVE_RAND 1
+
+/* Define to 1 if you have the <stdarg.h> header file. */
+/* #undef HAVE_STDARG_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+/* #undef HAVE_STDINT_H */
+
+/* Define to 1 if you have the <stdio.h> header file. */
+/* #undef HAVE_STDIO_H */
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if function std::rand is available */
+#define HAVE_STD__RAND 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #define HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <time.h> header file. */
+/* #undef HAVE_TIME_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #define HAVE_UNISTD_H */
+
+/* Define to 1 if va_copy is avaliable */
+/* #undef HAVE_VA_COPY */
+
+/* Define to 1 if you have the <windows.h> header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Define to 1 if you have the `_snprintf' function. */
+#define HAVE__SNPRINTF 1
+
+/* The size of a `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE 8
+
+/* The size of a `int', as computed by sizeof. */
+#define SIZEOF_INT 4
+
+/* The size of a `int *', as computed by sizeof. */
+#define SIZEOF_INT_P 8
+
+/* The size of a `long', as computed by sizeof. */
+#define SIZEOF_LONG 4
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1


### PR DESCRIPTION
Add VS2022 and its windows-ci to stable 0.60 and add configall_system files from master.

The Windows-ci is the same as used in [PR 214 of CoinUtils](https://github.com/coin-or/CoinUtils/pull/214).

