### PR TITLE
Directly include cmath

### DIFF
--- a/src/CglLandP/CglLandPValidator.cpp
+++ b/src/CglLandP/CglLandPValidator.cpp
@@ -11,14 +11,7 @@
 #include "CoinPackedMatrix.hpp"
 #include "OsiRowCut.hpp"
 
-#ifdef HAVE_CMATH
-# include <cmath>
-#else
-# ifdef HAVE_MATH_H
-#  include <math.h>
-# endif
-#endif
-
+#include <cmath>
 
 namespace LAP
 {


### PR DESCRIPTION
Other source files already assume that cmath is available. The same can be done here, too.