### PR TITLE
don't call memcpy with potential nullptr

### DIFF
--- a/src/CglCommon/CglTreeInfo.cpp
+++ b/src/CglCommon/CglTreeInfo.cpp
@@ -1249,11 +1249,13 @@ bool CglTreeProbingInfo::fixes(int variable, int toValue, int fixedVariable, boo
       return false;
     maximumEntries_ += 100 + maximumEntries_ / 2;
     CliqueEntry *temp1 = new CliqueEntry[maximumEntries_];
-    memcpy(temp1, fixEntry_, numberEntries_ * sizeof(CliqueEntry));
+    if (fixEntry_)
+      memcpy(temp1, fixEntry_, numberEntries_ * sizeof(CliqueEntry));
     delete[] fixEntry_;
     fixEntry_ = temp1;
     int *temp2 = new int[maximumEntries_];
-    memcpy(temp2, fixingEntry_, numberEntries_ * sizeof(int));
+    if (fixingEntry_)
+      memcpy(temp2, fixingEntry_, numberEntries_ * sizeof(int));
     delete[] fixingEntry_;
     fixingEntry_ = temp2;
   }


### PR DESCRIPTION
that is undefined
caught by clang ubsan

avoids alarms like:

```
1	
3: Warning: Debug: Encountered old-style message: '/local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglCommon/CglTreeInfo.cpp:1252:19: runtime error: null pointer passed as argument 2, which is declared to never be null'
2	
3: Warning: Debug: Encountered old-style message: '/usr/include/string.h:44:28: note: nonnull attribute specified here'
3	
3: Warning: Debug: Encountered old-style message: '    #0 0x55e47e7ac13a in CglTreeProbingInfo::fixes(int, int, int, bool) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglCommon/CglTreeInfo.cpp:1252:5'
4	
3: Warning: Debug: Encountered old-style message: '    #1 0x55e47e9b15d8 in CglProbing::probe(OsiSolverInterface const&, OsiRowCutDebugger const*, OsiCuts&, double*, double*, CoinPackedMatrix*, CoinPackedMatrix*, int const*, int const*, double const*, double const*, char const*, double*, double*, int*, CglTreeInfo*) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglProbing/CglProbing.cpp:5569:26'
5	
3: Warning: Debug: Encountered old-style message: '    #2 0x55e47e9830fe in CglProbing::gutsOfGenerateCuts(OsiSolverInterface const&, OsiCuts&, double*, double*, double*, double*, CglTreeInfo*) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglProbing/CglProbing.cpp:2383:20'
6	
3: Warning: Debug: Encountered old-style message: '    #3 0x55e47e986573 in CglProbing::generateCutsAndModify(OsiSolverInterface const&, OsiCuts&, CglTreeInfo*) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglProbing/CglProbing.cpp:1452:15'
7	
3: Warning: Debug: Encountered old-style message: '    #4 0x55e47e92b2df in CglPreProcess::modified(OsiSolverInterface*, bool, int&, int, int) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglPreProcess/CglPreProcess.cpp:7373:23'
8	
3: Warning: Debug: Encountered old-style message: '    #5 0x55e47e900b6b in CglPreProcess::preProcessNonDefault(OsiSolverInterface&, int, int, int) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cgl/src/CglPreProcess/CglPreProcess.cpp:3653:38'
9	
3: Warning: Debug: Encountered old-style message: '    #6 0x55e47e56df76 in CbcMain1(std::__1::deque<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, CbcModel&, CbcParameters&, int (*)(CbcModel*, int), ampl_info*) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cbc/src/CbcSolver.cpp:4869:39'
10	
3: Warning: Debug: Encountered old-style message: '    #7 0x55e47e5cbae3 in CbcMain1(int, char const**, CbcModel&, CbcParameters&, int (*)(CbcModel*, int), ampl_info*) /local/makefactory/libcbc-pVywhz9L/libcbc/src/Cbc/src/CbcSolver.cpp:13400:10'
```